### PR TITLE
Borg Water change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -225,6 +225,7 @@
   - type: InGas
     gasId: 9
     damagedByGas: true
+    gasThreshold: 20
     damage:
         types:
             Shock: 5


### PR DESCRIPTION
Borgs now require 20 mol of water to take damage from

