### PR TITLE
Tweaked PDA Wireless Ranged.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -74,7 +74,7 @@
     prefix: device-address-prefix-console
     savableAddress: false
   - type: WirelessNetworkConnection
-    range: 500
+    range: 999999999999999999999999
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
     preinstalled:


### PR DESCRIPTION
Made it so the PDA manifest works on sweetwater.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the wireless range on the PDA to a large number,

## Why / Balance
To hopefully make it work on sweetwater

## Technical details
Changed it from 500 to 9999999999

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
If this breaks, just change the large number in wireless range to 500.

**Changelog**
- Tweaked PDA Wireless range.
-->
