### PR TITLE
change odds to 20

### DIFF
--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -200,7 +200,7 @@
   components:
   - type: StationEvent
     earliestStart: 0
-    minimumPlayers: 10 # need at least a LITTLE prey
+    minimumPlayers: 20 # need at least a LITTLE prey
     maxOccurrences: 1
     weight: 6
   - type: OceanSpawnRule


### PR DESCRIPTION
because someone murderboned and it was very unfun for everyone else.
**Changelog**
- :cl: tweak: Changed odds that mimics can spawn based on playerpop to 20

