### PR TITLE
Teto, Miku, and Teto to the correct vending machine

### DIFF
--- a/Resources/Prototypes/_TP/Catalog/VendingMachines/Inventory/clothesvend.yml
+++ b/Resources/Prototypes/_TP/Catalog/VendingMachines/Inventory/clothesvend.yml
@@ -129,6 +129,17 @@
     ClothingHeadHatCanadaBeanie: 4
     ClothingHeadHatSantahat: 2
     ClothingHeadHatXmasCrown: 2
+    #Far Horizons-Start
+    ClothingShoesBootsPerformer: 2
+    ClothingUniformJumpskirtPerformer: 2
+    ClothingHeadPerformerWig: 2
+    TP14ClothingShoesBootsDarkPerformer: 2
+    TP14ClothingUniformJumpskirtDarkPerformer: 2
+    ClothingHeadDarkPerformerWig: 2
+    ClothingShoesBootsBrightPerformer: 2
+    ClothingUniformJumpskirtBrightPerformer: 2
+    ClothingHeadBrightPerformerWig: 2
+    #Far Horizons-End
   contrabandInventory:
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1


### PR DESCRIPTION

## About the PR
Adds the actually vending machine this is meant to be in.
(sorry pix)
## Why / Balance
Same as last, cool clothing

## Technical details
something something adds clothing to a vending machine
## Media
<img width="494" height="506" alt="Screenshot 2026-03-16 113037" src="https://github.com/user-attachments/assets/ee71e7d7-9a14-48ed-807c-c8f1b43077e1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl:
- add: Neru, Miku, and Teto to the CORRECT VENDING MACHINE (Clothing-vend)
-->
