### PR TITLE
Update CrewManifestCartridgeSystem.cs

### DIFF
--- a/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.CrewManifest;
 using Content.Server.Station.Systems;
 using Content.Shared.CartridgeLoader;
@@ -9,6 +10,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.CartridgeLoader.Cartridges;
 
+// !! TRIESTE MODIFIED !! //
 public sealed class CrewManifestCartridgeSystem : EntitySystem
 {
     [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
@@ -37,7 +39,7 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
     /// The ui messages received here get wrapped by a CartridgeMessageEvent and are relayed from the <see cref="CartridgeLoaderSystem"/>
     /// </summary>
     /// <remarks>
-    /// The cartridge specific ui message event needs to inherit from the CartridgeMessageEvent
+    /// The cartridge-specific ui message event needs to inherit from the CartridgeMessageEvent
     /// </remarks>
     private void OnUiMessage(EntityUid uid, CrewManifestCartridgeComponent component, CartridgeMessageEvent args)
     {
@@ -57,12 +59,12 @@ public sealed class CrewManifestCartridgeSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        var owningStation = _stationSystem.GetOwningStation(uid);
+        // TRIESTE:
+        // A fix for the Sweetwater PDA issue.
+        // Just get the first station available, which is Trieste. (for now!)
+        var owningStation = _stationSystem.GetOwningStation(uid) ?? _stationSystem.GetStations().FirstOrDefault();
 
-        if (owningStation is null)
-            return;
-
-        var (stationName, entries) = _crewManifest.GetCrewManifest(owningStation.Value);
+        var (stationName, entries) = _crewManifest.GetCrewManifest(owningStation);
 
         var state = new CrewManifestUiState(stationName, entries);
         _cartridgeLoader.UpdateCartridgeUiState(loaderUid, state);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I modified the Crew Manifest system so it now works in Sweetwater.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's been bugged forever on our fork. While the fix isn't perfect, it should be fine for our needs.

## Technical details
<!-- Summary of code changes for easier review. -->
Modified `Content.Server/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs` to check for the first or default station. (Trieste)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="967" height="906" alt="image" src="https://github.com/user-attachments/assets/89e93b59-4c29-4211-a1f4-7a6ca9530840" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* None as long as we stick to a single station lol

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the Crew Manifest forever loading in Sweetwater.
